### PR TITLE
openamp-demo-notebooks: add openamp.dtb note

### DIFF
--- a/openamp/apu-start-rpu.ipynb
+++ b/openamp/apu-start-rpu.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "source": [
     "### Setup <a name=\"AstartR_setup\"></a>\n",
-    "We are using the PetaLinux pre-built images in these examples. For the pre-built kernel images, device tree binary or blobs (e.g.: system.dtb), root file system archives and other files, please find the `images` directory in your PetaLinux project. For example: `pre-built/linux/images`.\n",
+    "We are using the PetaLinux pre-built images in these examples. The test system should be booted using openamp.dtb device tree, which is different from the default system.dtb. For the pre-built kernel images, device tree binaries (openamp.dtb), root file system archives and other files, please find the `images` directory in your PetaLinux project. For example: `pre-built/linux/images`.\n",
     "\n",
     "Aside from the master OS (e.g.: Linux) support, the demos require two executables:\n",
     "1. RPU application or firmware is Cortex-R binary, used as an offloading server\n",


### PR DESCRIPTION
Update Setup section to add a note that the test system should be booted using openamp.dtb and not the default system.dtb.